### PR TITLE
Shaman Items Tooltip, OnSpawn() and fix PreDraw() in OrchidModProjectile

### DIFF
--- a/Gambler/Projectiles/KingSlimeCardProj.cs
+++ b/Gambler/Projectiles/KingSlimeCardProj.cs
@@ -154,8 +154,10 @@ namespace OrchidMod.Gambler.Projectiles
 			SlimePostAITrail();
 		}
 		
-		public override void SafePreDraw(SpriteBatch spriteBatch, Color lightColor) {
+		public override bool OrchidPreDraw(SpriteBatch spriteBatch, Color lightColor) 
+		{
 			SlimePreDrawTrail(spriteBatch, lightColor);
+			return true;
 		}
 		
 		public void SlimePreDrawTrail(SpriteBatch spriteBatch, Color lightColor)

--- a/OrchidModProjectile.cs
+++ b/OrchidModProjectile.cs
@@ -15,23 +15,6 @@ namespace OrchidMod
 		public float projectileTrailOffset = 0f; // Offcenters the afterimages a bit. useless without projectileTrail activated. Looks terrible on most projectiles.
 		public bool initialized; // Used in various AI.
 		public bool projOwner = false;
-		
-		protected bool spawned; // Required for OnSpawn()
-
-		public sealed override bool PreAI()
-		{
-			if (!spawned)
-			{
-				spawned = true;
-				OnSpawn();
-			}
-
-			return OrchidPreAI();
-		}
-
-		public virtual bool OrchidPreAI() { return true; }
-
-		public virtual void OnSpawn() { } // Called when projectile is created
 
 		public virtual void AltSetDefaults() {}
 		

--- a/OrchidModProjectile.cs
+++ b/OrchidModProjectile.cs
@@ -36,8 +36,6 @@ namespace OrchidMod
 		public virtual void AltSetDefaults() {}
 		
 		public virtual void SafeSetDefaults() {}
-		
-		public virtual void SafePreDraw(SpriteBatch spriteBatch, Color lightColor) {}
 			
 		public virtual void SafePostAI() {}
 	
@@ -45,13 +43,16 @@ namespace OrchidMod
 			AltSetDefaults();
 		}
 		
-		public sealed override bool PreDraw(SpriteBatch spriteBatch, Color lightColor) {
-			SafePreDraw(spriteBatch, lightColor);
-			if (this.projectileTrail) {
+		public sealed override bool PreDraw(SpriteBatch spriteBatch, Color lightColor)
+		{
+			if (projectileTrail) 
+			{
 				PreDrawTrail(spriteBatch, lightColor);
 			}
-			return true;
+			return OrchidPreDraw(spriteBatch, lightColor);
 		}
+
+		public virtual bool OrchidPreDraw(SpriteBatch spriteBatch, Color lightColor) { return true; }
 		
 		public sealed override void PostAI() {
 			SafePostAI();

--- a/OrchidModProjectile.cs
+++ b/OrchidModProjectile.cs
@@ -15,6 +15,23 @@ namespace OrchidMod
 		public float projectileTrailOffset = 0f; // Offcenters the afterimages a bit. useless without projectileTrail activated. Looks terrible on most projectiles.
 		public bool initialized; // Used in various AI.
 		public bool projOwner = false;
+		
+		protected bool spawned; // Required for OnSpawn()
+
+		public sealed override bool PreAI()
+		{
+			if (!spawned)
+			{
+				spawned = true;
+				OnSpawn();
+			}
+
+			return OrchidPreAI();
+		}
+
+		public virtual bool OrchidPreAI() { return true; }
+
+		public virtual void OnSpawn() { } // Called when projectile is created
 
 		public virtual void AltSetDefaults() {}
 		

--- a/Shaman/OrchidModShamanItem.cs
+++ b/Shaman/OrchidModShamanItem.cs
@@ -72,74 +72,22 @@ namespace OrchidMod.Shaman
 				}
 			}
 			
-			if (this.empowermentType > 0) {
-				string emp = "";
-				Color col = new Color(0, 0, 0);
-				switch (this.empowermentType) {
-					case 1:
-						emp = "Fire";
-						col = new Color(194, 38, 31);
-						break;
-					case 2:
-						emp = "Water";
-						col = new Color(0, 119, 190);
-						break;
-					case 3:
-						emp = "Air";
-						col = new Color(75, 139, 59);
-						break;
-					case 4:
-						emp = "Earth";
-						col = new Color(255, 255, 102);
-						break;
-					case 5:
-						emp = "Spirit";
-						col = new Color(138, 43, 226);
-						break;
-					default:
-						break;
-				}
-				
-				int index = tooltips.FindIndex(ttip => ttip.mod.Equals("Terraria") && ttip.Name.Equals("Tooltip0"));
-				if (index != -1)
+			if (empowermentType > 0)
+			{
+				Color[] colors = new Color[5]
 				{
-					tooltips.Insert(index, new TooltipLine(mod, "BondType", emp + " bond")
-					{
-						overrideColor = col
-					});
-				}
-			}
-			
-			if (this.empowermentLevel > 0) {
-				string lev = "";
-				switch (this.empowermentLevel) {
-					case 1:
-						lev = "I";
-						break;
-					case 2:
-						lev = "II";
-						break;
-					case 3:
-						lev = "III";
-						break;
-					case 4:
-						lev = "IV";
-						break;
-					case 5:
-						lev = "V";
-						break;
-					default:
-						break;
-				}
-				
+					new Color(194, 38, 31),
+					new Color(0, 119, 190),
+				    new Color(75, 139, 59),
+					new Color(255, 255, 102),
+					new Color(138, 43, 226)
+				};
+
+				string[] strType = new string[5] { "Fire", "Water", "Air", "Earth", "Spirit" };
+				string[] strLevel = new string[5] { "I", "II", "III", "IV", "V" };
+
 				int index = tooltips.FindIndex(ttip => ttip.mod.Equals("Terraria") && ttip.Name.Equals("Tooltip0"));
-				if (index != -1)
-				{
-					tooltips.Insert(index, new TooltipLine(mod, "BondLevel", "Shamanic bond level " + lev)
-					{
-						overrideColor = new Color(0, 192, 255)
-					});
-				}
+				if (index != -1) tooltips.Insert(index, new TooltipLine(mod, "BondType", $"Bond type: [c/{Terraria.ID.Colors.AlphaDarken(colors[empowermentType - 1]).Hex3()}:{strType[empowermentType - 1]} {strLevel[empowermentLevel - 1]}]"));
 			}
 		}
 	}


### PR DESCRIPTION
For me, the shaman's tooltips are too cumbersome. I would prefer that they were significantly shorter.

**Example:**
> Before:
> ![image](https://user-images.githubusercontent.com/36926642/109440360-1776ef00-7a43-11eb-8ea6-b7e909599388.png)
> After:
> ![image](https://user-images.githubusercontent.com/36926642/109440375-265da180-7a43-11eb-9fdb-e7da360b4f58.png)

About OnSpawn(): This Action is very useful. I saw that PreAI() is not used anywhere, so you don't have to change anything in the old classes...