### PR TITLE
Thorium 1.6.5.0 compatibility, various small fixes

### DIFF
--- a/Alchemist/Misc/ReactionItem.cs
+++ b/Alchemist/Misc/ReactionItem.cs
@@ -47,7 +47,7 @@ namespace OrchidMod.Alchemist.Misc
 		}
 		
 		public override void ModifyTooltips(List<TooltipLine> tooltips) {
-			Mod thoriumMod = ModLoader.GetMod("ThoriumMod");
+			Mod thoriumMod = OrchidMod.ThoriumMod;
 			if (thoriumMod != null) {
 				tooltips.Insert(1, new TooltipLine(mod, "ClassTag", "-Alchemist Class-")
 				{

--- a/Alchemist/Misc/UIItem.cs
+++ b/Alchemist/Misc/UIItem.cs
@@ -61,7 +61,7 @@ namespace OrchidMod.Alchemist.Misc
 		*/
 		
 		public override void ModifyTooltips(List<TooltipLine> tooltips) {
-			Mod thoriumMod = ModLoader.GetMod("ThoriumMod");
+			Mod thoriumMod = OrchidMod.ThoriumMod;
 			if (thoriumMod != null) {
 				tooltips.Insert(1, new TooltipLine(mod, "ClassTag", "-Alchemist Class-")
 				{

--- a/Alchemist/Misc/UIItemKeys.cs
+++ b/Alchemist/Misc/UIItemKeys.cs
@@ -62,7 +62,7 @@ namespace OrchidMod.Alchemist.Misc
 		*/
 		
 		public override void ModifyTooltips(List<TooltipLine> tooltips) {
-			Mod thoriumMod = ModLoader.GetMod("ThoriumMod");
+			Mod thoriumMod = OrchidMod.ThoriumMod;
 			if (thoriumMod != null) {
 				tooltips.Insert(1, new TooltipLine(mod, "ClassTag", "-Alchemist Class-")
 				{

--- a/Alchemist/OrchidModAlchemistCatalyst.cs
+++ b/Alchemist/OrchidModAlchemistCatalyst.cs
@@ -106,7 +106,7 @@ namespace OrchidMod.Alchemist
 		}
 
 		public override void ModifyTooltips(List<TooltipLine> tooltips) {
-			Mod thoriumMod = ModLoader.GetMod("ThoriumMod");
+			Mod thoriumMod = OrchidMod.ThoriumMod;
 			if (thoriumMod != null) {
 				tooltips.Insert(1, new TooltipLine(mod, "ClassTag", "-Alchemist Class-")
 				{

--- a/Alchemist/OrchidModAlchemistEquipable.cs
+++ b/Alchemist/OrchidModAlchemistEquipable.cs
@@ -32,7 +32,7 @@ namespace OrchidMod.Alchemist
 				tt.text = damageValue + " chemical " + damageWord;
 			}
 			
-			Mod thoriumMod = ModLoader.GetMod("ThoriumMod");
+			Mod thoriumMod = OrchidMod.ThoriumMod;
 			if (thoriumMod != null) {
 				tooltips.Insert(1, new TooltipLine(mod, "ClassTag", "-Alchemist Class-")
 				{

--- a/Alchemist/OrchidModAlchemistItem.cs
+++ b/Alchemist/OrchidModAlchemistItem.cs
@@ -226,7 +226,7 @@ namespace OrchidMod.Alchemist
 				overrideColor = new Color(155, 255, 155)
 			});
 			
-			Mod thoriumMod = ModLoader.GetMod("ThoriumMod");
+			Mod thoriumMod = OrchidMod.ThoriumMod;
 			if (thoriumMod != null) {
 				tooltips.Insert(1, new TooltipLine(mod, "ClassTag", "-Alchemist Class-")
 				{

--- a/Alchemist/OrchidModAlchemistMisc.cs
+++ b/Alchemist/OrchidModAlchemistMisc.cs
@@ -56,7 +56,7 @@ namespace OrchidMod.Alchemist
 				tt.text = damageValue + " chemical " + damageWord;
 			}
 			
-			Mod thoriumMod = ModLoader.GetMod("ThoriumMod");
+			Mod thoriumMod = OrchidMod.ThoriumMod;
 			if (thoriumMod != null) {
 				tooltips.Insert(1, new TooltipLine(mod, "ClassTag", "-Alchemist Class-")
 				{

--- a/Alchemist/OrchidModAlchemistScroll.cs
+++ b/Alchemist/OrchidModAlchemistScroll.cs
@@ -53,7 +53,7 @@ namespace OrchidMod.Alchemist
 		}
 
 		public override void ModifyTooltips(List<TooltipLine> tooltips) {
-			Mod thoriumMod = ModLoader.GetMod("ThoriumMod");
+			Mod thoriumMod = OrchidMod.ThoriumMod;
 			if (thoriumMod != null) {
 				tooltips.Insert(1, new TooltipLine(mod, "ClassTag", "-Alchemist Class-")
 				{

--- a/Dancer/OrchidModDancerItem.cs
+++ b/Dancer/OrchidModDancerItem.cs
@@ -100,7 +100,7 @@ namespace OrchidMod.Dancer
 				});
 			}
 			
-			Mod thoriumMod = ModLoader.GetMod("ThoriumMod");
+			Mod thoriumMod = OrchidMod.ThoriumMod;
 			if (thoriumMod != null) {
 				tooltips.Insert(1, new TooltipLine(mod, "ClassTag", "-Dancer Class-")
 				{

--- a/Gambler/Accessories/VultureCharm.cs
+++ b/Gambler/Accessories/VultureCharm.cs
@@ -33,12 +33,11 @@ namespace OrchidMod.Gambler.Accessories
 		
 		public override void AddRecipes()
 		{
-			Mod thoriumMod = ModLoader.GetMod("ThoriumMod");
-			Mod orchidMod = ModLoader.GetMod("OrchidMod");
+			Mod thoriumMod = OrchidMod.ThoriumMod;
 			
 		    ModRecipe recipe = new ModRecipe(mod);
 			recipe.AddRecipeGroup("IronBar", 5);
-			recipe.AddIngredient((thoriumMod != null) ? thoriumMod.ItemType("BirdTalon") : orchidMod.ItemType("VultureTalon"), 3);
+			recipe.AddIngredient((thoriumMod != null) ? thoriumMod.ItemType("BirdTalon") : mod.ItemType("VultureTalon"), 3);
 			recipe.AddTile(TileID.Anvils);
             recipe.SetResult(this);
             recipe.AddRecipe();

--- a/Gambler/Armors/Outlaw/OutlawHat.cs
+++ b/Gambler/Armors/Outlaw/OutlawHat.cs
@@ -5,6 +5,7 @@ using Terraria.ID;
 using Terraria.ModLoader;
 using Microsoft.Xna.Framework;
 using static Terraria.ModLoader.ModContent;
+using OrchidMod.Gambler.Misc;
 
 namespace OrchidMod.Gambler.Armors.Outlaw
 {
@@ -57,13 +58,12 @@ namespace OrchidMod.Gambler.Armors.Outlaw
 		
 		public override void AddRecipes()
 		{
-			Mod thoriumMod = ModLoader.GetMod("ThoriumMod");
-			Mod orchidMod = ModLoader.GetMod("OrchidMod");
+			Mod thoriumMod = OrchidMod.ThoriumMod;
 			
 		    ModRecipe recipe = new ModRecipe(mod);
 			recipe.AddIngredient(ItemID.Silk, 5);
 			recipe.AddIngredient(ItemID.GoldBar, 5);
-			recipe.AddIngredient((thoriumMod != null) ? thoriumMod.ItemType("BirdTalon") : orchidMod.ItemType("VultureTalon"), 2);
+			recipe.AddIngredient((thoriumMod != null) ? thoriumMod.ItemType("BirdTalon") : ItemType<VultureTalon>(), 2);
 			recipe.AddTile(TileID.Anvils);
             recipe.SetResult(this);
             recipe.AddRecipe();
@@ -71,7 +71,7 @@ namespace OrchidMod.Gambler.Armors.Outlaw
 			recipe = new ModRecipe(mod);
 			recipe.AddIngredient(ItemID.Silk, 5);
 			recipe.AddIngredient(ItemID.PlatinumBar, 5);
-			recipe.AddIngredient((thoriumMod != null) ? thoriumMod.ItemType("BirdTalon") : orchidMod.ItemType("VultureTalon"), 2);
+			recipe.AddIngredient((thoriumMod != null) ? thoriumMod.ItemType("BirdTalon") : ItemType<VultureTalon>(), 2);
 			recipe.AddTile(TileID.Anvils);
             recipe.SetResult(this);
             recipe.AddRecipe();

--- a/Gambler/Armors/Outlaw/OutlawPants.cs
+++ b/Gambler/Armors/Outlaw/OutlawPants.cs
@@ -3,6 +3,8 @@ using Terraria;
 using Terraria.ID;
 using Terraria.ModLoader;
 using Microsoft.Xna.Framework;
+using OrchidMod.Gambler.Misc;
+using static Terraria.ModLoader.ModContent;
 
 namespace OrchidMod.Gambler.Armors.Outlaw
 {
@@ -32,13 +34,12 @@ namespace OrchidMod.Gambler.Armors.Outlaw
 		
 		public override void AddRecipes()
 		{
-			Mod thoriumMod = ModLoader.GetMod("ThoriumMod");
-			Mod orchidMod = ModLoader.GetMod("OrchidMod");
+			Mod thoriumMod = OrchidMod.ThoriumMod;
 			
 		    ModRecipe recipe = new ModRecipe(mod);
 			recipe.AddIngredient(ItemID.Silk, 6);
 			recipe.AddIngredient(ItemID.GoldBar, 10);
-			recipe.AddIngredient((thoriumMod != null) ? thoriumMod.ItemType("BirdTalon") : orchidMod.ItemType("VultureTalon"), 3);
+			recipe.AddIngredient((thoriumMod != null) ? thoriumMod.ItemType("BirdTalon") : ItemType<VultureTalon>(), 3);
 			recipe.AddTile(TileID.Anvils);
             recipe.SetResult(this);
             recipe.AddRecipe();
@@ -46,7 +47,7 @@ namespace OrchidMod.Gambler.Armors.Outlaw
 			recipe = new ModRecipe(mod);
 			recipe.AddIngredient(ItemID.Silk, 6);
 			recipe.AddIngredient(ItemID.PlatinumBar, 10);
-			recipe.AddIngredient((thoriumMod != null) ? thoriumMod.ItemType("BirdTalon") : orchidMod.ItemType("VultureTalon"), 3);
+			recipe.AddIngredient((thoriumMod != null) ? thoriumMod.ItemType("BirdTalon") : ItemType<VultureTalon>(), 3);
 			recipe.AddTile(TileID.Anvils);
             recipe.SetResult(this);
             recipe.AddRecipe();

--- a/Gambler/Armors/Outlaw/OutlawVest.cs
+++ b/Gambler/Armors/Outlaw/OutlawVest.cs
@@ -3,6 +3,8 @@ using Terraria;
 using Terraria.ID;
 using Terraria.ModLoader;
 using Microsoft.Xna.Framework;
+using static Terraria.ModLoader.ModContent;
+using OrchidMod.Gambler.Misc;
 
 namespace OrchidMod.Gambler.Armors.Outlaw
 {
@@ -37,13 +39,12 @@ namespace OrchidMod.Gambler.Armors.Outlaw
 		
 		public override void AddRecipes()
 		{
-			Mod thoriumMod = ModLoader.GetMod("ThoriumMod");
-			Mod orchidMod = ModLoader.GetMod("OrchidMod");
+			Mod thoriumMod = OrchidMod.ThoriumMod;
 			
 		    ModRecipe recipe = new ModRecipe(mod);
 			recipe.AddIngredient(ItemID.Silk, 7);
 			recipe.AddIngredient(ItemID.GoldBar, 15);
-			recipe.AddIngredient((thoriumMod != null) ? thoriumMod.ItemType("BirdTalon") : orchidMod.ItemType("VultureTalon"), 4);
+			recipe.AddIngredient((thoriumMod != null) ? thoriumMod.ItemType("BirdTalon") : ItemType<VultureTalon>(), 4);
 			recipe.AddTile(TileID.Anvils);
             recipe.SetResult(this);
             recipe.AddRecipe();
@@ -51,7 +52,7 @@ namespace OrchidMod.Gambler.Armors.Outlaw
 			recipe = new ModRecipe(mod);
 			recipe.AddIngredient(ItemID.Silk, 7);
 			recipe.AddIngredient(ItemID.PlatinumBar, 15);
-			recipe.AddIngredient((thoriumMod != null) ? thoriumMod.ItemType("BirdTalon") : orchidMod.ItemType("VultureTalon"), 4);
+			recipe.AddIngredient((thoriumMod != null) ? thoriumMod.ItemType("BirdTalon") : ItemType<VultureTalon>(), 4);
 			recipe.AddTile(TileID.Anvils);
             recipe.SetResult(this);
             recipe.AddRecipe();

--- a/Gambler/GamblerDeck.cs
+++ b/Gambler/GamblerDeck.cs
@@ -107,7 +107,7 @@ namespace OrchidMod.Gambler
 		}
 		
 		public override void ModifyTooltips(List<TooltipLine> tooltips) {
-			Mod thoriumMod = ModLoader.GetMod("ThoriumMod");
+			Mod thoriumMod = OrchidMod.ThoriumMod;
 			if (thoriumMod != null) {
 				tooltips.Insert(1, new TooltipLine(mod, "ClassTag", "-Gambler Class-")
 				{

--- a/Gambler/GamblerDummy.cs
+++ b/Gambler/GamblerDummy.cs
@@ -98,7 +98,7 @@ namespace OrchidMod.Gambler
 		}
 		
 		public override void ModifyTooltips(List<TooltipLine> tooltips) {
-			Mod thoriumMod = ModLoader.GetMod("ThoriumMod");
+			Mod thoriumMod = OrchidMod.ThoriumMod;
 			if (thoriumMod != null) {
 				tooltips.Insert(1, new TooltipLine(mod, "ClassTag", "-Gambler Class-")
 				{

--- a/Gambler/GamblerDummyTest.cs
+++ b/Gambler/GamblerDummyTest.cs
@@ -97,7 +97,7 @@ namespace OrchidMod.Gambler
 		}
 		
 		public override void ModifyTooltips(List<TooltipLine> tooltips) {
-			Mod thoriumMod = ModLoader.GetMod("ThoriumMod");
+			Mod thoriumMod = OrchidMod.ThoriumMod;
 			if (thoriumMod != null) {
 				tooltips.Insert(1, new TooltipLine(mod, "ClassTag", "-Gambler Class-")
 				{

--- a/Gambler/Misc/VulturePotion.cs
+++ b/Gambler/Misc/VulturePotion.cs
@@ -35,15 +35,14 @@ namespace OrchidMod.Gambler.Misc
     }
 		public override void AddRecipes()
 		{
-			Mod orchidMod = ModLoader.GetMod("OrchidMod");
-			Mod thoriumMod = ModLoader.GetMod("ThoriumMod");
+			Mod thoriumMod = OrchidMod.ThoriumMod;
 
 		    ModRecipe recipe = new ModRecipe(mod);
 			recipe.AddTile(TileID.Bottles);	
 			recipe.AddIngredient(ItemID.BottledWater, 1);
 			recipe.AddIngredient(ItemID.Blinkroot, 1);
 			recipe.AddIngredient(ItemID.Cactus, 1);
-			recipe.AddIngredient((thoriumMod != null) ? thoriumMod.ItemType("BirdTalon") : ItemType<Gambler.Misc.VultureTalon>(), 2);
+			recipe.AddIngredient((thoriumMod != null) ? thoriumMod.ItemType("BirdTalon") : ItemType<VultureTalon>(), 2);
 			recipe.SetResult(this);
 			recipe.AddRecipe();
         }

--- a/Gambler/OrchidModGamblerChipItem.cs
+++ b/Gambler/OrchidModGamblerChipItem.cs
@@ -69,7 +69,7 @@ namespace OrchidMod.Gambler
 				tt.text = damageValue + " gambling " + damageWord;
 			}
 				
-			Mod thoriumMod = ModLoader.GetMod("ThoriumMod");
+			Mod thoriumMod = OrchidMod.ThoriumMod;
 			if (thoriumMod != null) {
 				tooltips.Insert(1, new TooltipLine(mod, "ClassTag", "-Gambler Class-")
 				{

--- a/Gambler/OrchidModGamblerDice.cs
+++ b/Gambler/OrchidModGamblerDice.cs
@@ -64,7 +64,7 @@ namespace OrchidMod.Gambler
 		}
 
 		public override void ModifyTooltips(List<TooltipLine> tooltips) {
-			Mod thoriumMod = ModLoader.GetMod("ThoriumMod");
+			Mod thoriumMod = OrchidMod.ThoriumMod;
 			if (thoriumMod != null) {
 				tooltips.Insert(1, new TooltipLine(mod, "ClassTag", "-Gambler Class-")
 				{

--- a/Gambler/OrchidModGamblerEquipable.cs
+++ b/Gambler/OrchidModGamblerEquipable.cs
@@ -32,7 +32,7 @@ namespace OrchidMod.Gambler
 				tt.text = damageValue + " gambling " + damageWord;
 			}
 			
-			Mod thoriumMod = ModLoader.GetMod("ThoriumMod");
+			Mod thoriumMod = OrchidMod.ThoriumMod;
 			if (thoriumMod != null) {
 				tooltips.Insert(1, new TooltipLine(mod, "ClassTag", "-Gambler Class-")
 				{

--- a/Gambler/OrchidModGamblerHelper.cs
+++ b/Gambler/OrchidModGamblerHelper.cs
@@ -17,7 +17,12 @@ namespace OrchidMod.Gambler
 	public class OrchidModGamblerHelper
 	{
 		public static void gamblerPostUpdateEquips(Player player, OrchidModPlayer modPlayer, Mod mod) {
-			modPlayer.gamblerHasCardInDeck = modPlayer.gamblerCardsItem[0].type != 0;
+			if (player.whoAmI == Main.myPlayer)
+			{
+				//Since this is a variable that is synced through SendClientChanges, it has to only be assigned on the client aswell
+				modPlayer.gamblerHasCardInDeck = modPlayer.gamblerCardsItem[0].type != 0;
+			}
+			
 			if (modPlayer.gamblerRedrawsMax > 0) {
 				modPlayer.gamblerRedrawCooldown = modPlayer.gamblerRedraws >= modPlayer.gamblerRedrawsMax ? modPlayer.gamblerRedrawCooldownMax : modPlayer.gamblerRedrawCooldown;
 				modPlayer.gamblerRedrawCooldown = modPlayer.gamblerRedrawCooldown > modPlayer.gamblerRedrawCooldownMax ? modPlayer.gamblerRedrawCooldownMax : modPlayer.gamblerRedrawCooldown;

--- a/Gambler/OrchidModGamblerItem.cs
+++ b/Gambler/OrchidModGamblerItem.cs
@@ -185,7 +185,7 @@ namespace OrchidMod.Gambler
 				});
 			}
 			
-			Mod thoriumMod = ModLoader.GetMod("ThoriumMod");
+			Mod thoriumMod = OrchidMod.ThoriumMod;
 			if (thoriumMod != null) {
 				tooltips.Insert(1, new TooltipLine(mod, "ClassTag", "-Gambler Class-")
 				{

--- a/General/Items/Misc/RCRemote.cs
+++ b/General/Items/Misc/RCRemote.cs
@@ -1,4 +1,3 @@
-using ExampleMod.Tiles;
 using Terraria;
 using Terraria.ID;
 using Terraria.ModLoader;

--- a/General/Items/Sets/StaticQuartz/Projectiles/StaticQuartzHealerPro.cs
+++ b/General/Items/Sets/StaticQuartz/Projectiles/StaticQuartzHealerPro.cs
@@ -9,7 +9,7 @@ namespace OrchidMod.General.Items.Sets.StaticQuartz.Projectiles
 {
 	public class StaticQuartzHealerPro : ModProjectile
 	{
-		Mod thoriumMod = ModLoader.GetMod("ThoriumMod");
+		Mod thoriumMod = OrchidMod.ThoriumMod;
 		
 		public override void SetStaticDefaults()
 		{
@@ -36,6 +36,7 @@ namespace OrchidMod.General.Items.Sets.StaticQuartz.Projectiles
 			ModPlayer thoriumPlayer = player.GetModPlayer(thoriumMod, "ThoriumPlayer");
 			npc.immune[projectile.owner] = 10;
 			
+			//TODO thorium
 			if (thoriumMod != null) {
 				if (projectile.penetrate > 99 && npc.CanBeChasedBy())
 				{
@@ -55,40 +56,49 @@ namespace OrchidMod.General.Items.Sets.StaticQuartz.Projectiles
 		public override void ModifyHitNPC(NPC target, ref int damage, ref float knockback, ref bool crit, ref int hitDirection)
 		{
 			Player player = Main.player[projectile.owner];
-			ModPlayer thoriumPlayer = player.GetModPlayer(thoriumMod, "ThoriumPlayer");
 			hitDirection = target.Center.X < player.Center.X ? -1 : 1;
 			
-			if (thoriumMod != null) {
+			//TODO thorium
+			if (thoriumMod != null)
+			{
+				ModPlayer thoriumPlayer = player.GetModPlayer(thoriumMod, "ThoriumPlayer");
 				FieldInfo critField = thoriumPlayer.GetType().GetField("radiantCrit", BindingFlags.Public | BindingFlags.Instance);
-				if (critField != null) {
+				if (critField != null)
+				{
 					int healCrit = (int)critField.GetValue(thoriumPlayer);
-					if (Main.rand.Next(101) <= healCrit)
-						crit = true;
-					else crit = false;
-				} else {
+					crit = Main.rand.Next(101) <= healCrit;
+				}
+				else
+				{
 					crit = false;
 				}
 					
-				if (crit == true) {
+				if (crit)
+				{
 					FieldInfo fieldWarlock = thoriumPlayer.GetType().GetField("warlockSet", BindingFlags.Public | BindingFlags.Instance);
-					if (fieldWarlock != null) {
+					if (fieldWarlock != null)
+					{
 						bool healWarlock = (bool)fieldWarlock.GetValue(thoriumPlayer);
-							
-						if (healWarlock) {
-							if (player.ownedProjectileCounts[mod.ProjectileType("ShadowWisp")] < 15)
+
+						if (healWarlock && Main.rand.NextFloat() < 0.5f)
+						{
+							int shadowWispType = thoriumMod.ProjectileType("ShadowWisp");
+							if (player.ownedProjectileCounts[shadowWispType] < 15)
 							{
-								Projectile.NewProjectile((int)target.Center.X, (int)target.Center.Y, 0f, -2f, thoriumMod.ProjectileType("ShadowWisp"), (int)(projectile.damage * 0.75f), 0, Main.myPlayer);
+								Projectile.NewProjectile((int)target.Center.X, (int)target.Center.Y, 0f, -2f, shadowWispType, (int)(projectile.damage * 0.5f), 0, Main.myPlayer);
 							}
 						}
 					}	
 				}
 				
 				FieldInfo fieldIridescent = thoriumPlayer.GetType().GetField("iridescentSet", BindingFlags.Public | BindingFlags.Instance);
-				if (fieldIridescent != null) {
+				if (fieldIridescent != null)
+				{
 					bool healIridescent = (bool)fieldIridescent.GetValue(thoriumPlayer);
 
-					if (healIridescent && Main.rand.NextFloat() < 0.15f) {
-						Main.PlaySound(2, (int)projectile.position.X, (int)projectile.position.Y, 100, 1f, 0f);
+					if (healIridescent && Main.rand.NextFloat() < 0.15f)
+					{
+						Main.PlaySound(SoundID.Item, (int)projectile.Center.X, (int)projectile.Center.Y, 100, 1f, 0f);
 						for (int k = 0; k < 20; k++)
 						{
 							int dust = Dust.NewDust(target.position, target.width, target.height, 87, Main.rand.Next((int)-6f, (int)6f), Main.rand.Next((int)-6f, (int)6f), 0, default(Color), 1.25f);
@@ -99,21 +109,25 @@ namespace OrchidMod.General.Items.Sets.StaticQuartz.Projectiles
 							int dust = Dust.NewDust(target.position, target.width, target.height, 91, Main.rand.Next((int)-2f, (int)2f), Main.rand.Next((int)-2f, (int)2f), 0, default(Color), 1.15f);
 							Main.dust[dust].noGravity = true;
 						}
-						for (int k = 0; k < 255; k++)
+
+						int healNoEffects = thoriumMod.ProjectileType("HealNoEffects");
+						int heal = 0;
+						if (target.type != NPCID.TargetDummy)
 						{
-							Player ally = Main.player[k];
-							if (ally.active && ally != player && ally.statLife < ally.statLifeMax2 && Vector2.Distance(ally.Center, projectile.Center) < 500)
+							for (int k = 0; k < Main.maxPlayers; k++)
 							{
-								if (target.type != NPCID.TargetDummy)
+								Player ally = Main.player[k];
+								if (ally.active && ally != player && ally.statLife < ally.statLifeMax2 && ally.DistanceSQ(projectile.Center) < 500 * 500)
 								{
-									Projectile.NewProjectile(ally.Center.X, ally.Center.Y, 0f, 0f, thoriumMod.ProjectileType("RadiantHeal"), 0, 0, projectile.owner, 0, 0f);
+									Projectile.NewProjectile(ally.Center, Vector2.Zero, healNoEffects, 0, 0, projectile.owner, heal, ally.whoAmI);
 								}
 							}
 						}
-						for (int u = 0; u < 200; u++)
+
+						for (int u = 0; u < Main.maxNPCs; u++)
 						{
 							NPC enemyTarget = Main.npc[u];
-							if (enemyTarget.active && enemyTarget.type != NPCID.TargetDummy && !enemyTarget.friendly && Vector2.Distance(enemyTarget.Center, player.Center) < 250)
+							if (enemyTarget.CanBeChasedBy() && enemyTarget.DistanceSQ(player.Center) < 250 * 250)
 							{
 								enemyTarget.AddBuff(BuffID.Confused, 120, false);
 							}
@@ -137,20 +151,13 @@ namespace OrchidMod.General.Items.Sets.StaticQuartz.Projectiles
 				projectile.Kill();
 			}
 
-			if (player.direction > 0)
-			{
-				projectile.rotation += 0.25f;
-				projectile.spriteDirection = 1;
-			}
-			else
-			{
-				projectile.rotation -= 0.25f;
-				projectile.spriteDirection = -1;
-			}
+			int dir = (player.direction > 0).ToDirectionInt();
+			projectile.rotation += dir * 0.25f;
+			projectile.spriteDirection = dir;
 
 			player.heldProj = projectile.whoAmI;
-			projectile.position.X = player.Center.X - 50;
-			projectile.position.Y = player.Center.Y - 50;
+			projectile.Center = player.Center;
+			projectile.gfxOffY = player.gfxOffY;
 		}
 	}
 }

--- a/General/Items/Sets/StaticQuartz/Projectiles/StaticQuartzHealerPro.cs
+++ b/General/Items/Sets/StaticQuartz/Projectiles/StaticQuartzHealerPro.cs
@@ -62,7 +62,8 @@ namespace OrchidMod.General.Items.Sets.StaticQuartz.Projectiles
 			if (thoriumMod != null)
 			{
 				ModPlayer thoriumPlayer = player.GetModPlayer(thoriumMod, "ThoriumPlayer");
-				FieldInfo critField = thoriumPlayer.GetType().GetField("radiantCrit", BindingFlags.Public | BindingFlags.Instance);
+				Type playerType = thoriumPlayer.GetType();
+				FieldInfo critField = playerType.GetField("radiantCrit", BindingFlags.Public | BindingFlags.Instance);
 				if (critField != null)
 				{
 					int healCrit = (int)critField.GetValue(thoriumPlayer);
@@ -72,26 +73,23 @@ namespace OrchidMod.General.Items.Sets.StaticQuartz.Projectiles
 				{
 					crit = false;
 				}
-					
-				if (crit)
-				{
-					FieldInfo fieldWarlock = thoriumPlayer.GetType().GetField("warlockSet", BindingFlags.Public | BindingFlags.Instance);
-					if (fieldWarlock != null)
-					{
-						bool healWarlock = (bool)fieldWarlock.GetValue(thoriumPlayer);
 
-						if (healWarlock && Main.rand.NextFloat() < 0.5f)
+				FieldInfo fieldWarlock = playerType.GetField("warlockSet", BindingFlags.Public | BindingFlags.Instance);
+				if (fieldWarlock != null)
+				{
+					bool healWarlock = (bool)fieldWarlock.GetValue(thoriumPlayer);
+
+					if (healWarlock && Main.rand.NextFloat() < 0.5f)
+					{
+						int shadowWispType = thoriumMod.ProjectileType("ShadowWisp");
+						if (player.ownedProjectileCounts[shadowWispType] < 15)
 						{
-							int shadowWispType = thoriumMod.ProjectileType("ShadowWisp");
-							if (player.ownedProjectileCounts[shadowWispType] < 15)
-							{
-								Projectile.NewProjectile((int)target.Center.X, (int)target.Center.Y, 0f, -2f, shadowWispType, (int)(projectile.damage * 0.5f), 0, Main.myPlayer);
-							}
+							Projectile.NewProjectile((int)target.Center.X, (int)target.Center.Y, 0f, -2f, shadowWispType, (int)(projectile.damage * 0.5f), 0, Main.myPlayer);
 						}
-					}	
+					}
 				}
 				
-				FieldInfo fieldIridescent = thoriumPlayer.GetType().GetField("iridescentSet", BindingFlags.Public | BindingFlags.Instance);
+				FieldInfo fieldIridescent = playerType.GetField("iridescentSet", BindingFlags.Public | BindingFlags.Instance);
 				if (fieldIridescent != null)
 				{
 					bool healIridescent = (bool)fieldIridescent.GetValue(thoriumPlayer);

--- a/General/Items/Sets/StaticQuartz/StaticQuartzHealer.cs
+++ b/General/Items/Sets/StaticQuartz/StaticQuartzHealer.cs
@@ -8,11 +8,14 @@ using Terraria.ID;
 using Terraria.ModLoader;
 using static Terraria.ModLoader.ModContent;
 using OrchidMod.Interfaces;
+using OrchidMod.General.Items.Sets.StaticQuartz.Projectiles;
 
 namespace OrchidMod.General.Items.Sets.StaticQuartz
 {
 	public class StaticQuartzHealer : OrchidModItem, ICrossmodItem
 	{
+		Mod thoriumMod = OrchidMod.ThoriumMod;
+
 		public string CrossmodName => "Thorium Mod";
 
 		public override void SetDefaults()
@@ -32,7 +35,7 @@ namespace OrchidMod.General.Items.Sets.StaticQuartz
 			item.value = Item.sellPrice(0, 0, 5, 0);
 			item.rare = ItemRarityID.Blue;
 			item.UseSound = SoundID.Item1;
-			item.shoot = mod.ProjectileType("StaticQuartzHealerPro");
+			item.shoot = ProjectileType<StaticQuartzHealerPro>();
 			item.shootSpeed = 0.1f;
 			item.crit = 0;
 		}
@@ -46,7 +49,6 @@ namespace OrchidMod.General.Items.Sets.StaticQuartz
 		
 		public override void AddRecipes()
 		{
-			Mod thoriumMod = OrchidMod.ThoriumMod;
 			if (thoriumMod != null)
 			{
 				ModRecipe recipe = new ModRecipe(mod);
@@ -59,34 +61,31 @@ namespace OrchidMod.General.Items.Sets.StaticQuartz
 		
 		public override void ModifyWeaponDamage(Player player, ref float add, ref float mult, ref float flat)
 		{
-			Mod thoriumMod = OrchidMod.ThoriumMod;
 			if (thoriumMod != null)
 			{
-				ModPlayer thoriumPlayer = player.GetModPlayer(thoriumMod, "ThoriumPlayer");
-				FieldInfo field1 = thoriumPlayer.GetType().GetField("flatRadiantDamage", BindingFlags.Public | BindingFlags.Instance);
-				FieldInfo field2 = thoriumPlayer.GetType().GetField("radiantBoost", BindingFlags.Public | BindingFlags.Instance);
-				
-				if (field1 != null && field2 != null) {
-					int healDamage = (int)field1.GetValue(thoriumPlayer);
-					float healBoost = (float)field2.GetValue(thoriumPlayer);
-					
-					add = player.allDamage + (healBoost - 1);
-					mult = player.allDamageMult;
-					flat += Math.Abs(player.velocity.X + player.velocity.Y) > 2.5f ? healDamage + 3 : healDamage;
+				object result = thoriumMod.Call("GetHealerDamageMods", player);
+
+				if (result is ValueTuple<float, float, int> tuple)
+				{
+					float radiantBoost = tuple.Item1;
+					float radiantBoostMult = tuple.Item2;
+					int flatRadiantDamage = tuple.Item3;
+
+					add = player.allDamage + (radiantBoost - 1);
+					mult = player.allDamageMult + (radiantBoostMult - 1);
+					flat += Math.Abs(player.velocity.X + player.velocity.Y) > 2.5f ? flatRadiantDamage + 3 : flatRadiantDamage;
 				}
 			}
 		}
 		
 		public override void GetWeaponCrit(Player player, ref int crit)
 		{
-			Mod thoriumMod = OrchidMod.ThoriumMod;
 			if (thoriumMod != null)
 			{
-				ModPlayer thoriumPlayer = player.GetModPlayer(thoriumMod, "ThoriumPlayer");
-				FieldInfo field = thoriumPlayer.GetType().GetField("radiantCrit", BindingFlags.Public | BindingFlags.Instance);
-				if (field != null) {
-					int healCrit = (int)field.GetValue(thoriumPlayer);
-					crit = item.crit + healCrit;
+				object result = thoriumMod.Call("GetHealerCrit", player);
+				if (result is int healerCrit)
+				{
+					crit = item.crit + healerCrit;
 				}
 			}
 		}
@@ -102,9 +101,9 @@ namespace OrchidMod.General.Items.Sets.StaticQuartz
 		
 		public override void ModifyTooltips(List<TooltipLine> tooltips)
 		{
-			Mod thoriumMod = OrchidMod.ThoriumMod;
 			Player player = Main.player[Main.myPlayer];
-			
+
+			//TODO thorium
 			if (thoriumMod != null)
 			{
 				ModPlayer thoriumPlayer = player.GetModPlayer(thoriumMod, "ThoriumPlayer");

--- a/NPCs/Town/Croupier.cs
+++ b/NPCs/Town/Croupier.cs
@@ -57,7 +57,7 @@ namespace OrchidMod.NPCs.Town
 			// }
 		// }
 
-		public override bool CanTownNPCSpawn(int numTownNPCs, int money) { // TODO : get it to work in mp :(
+		public override bool CanTownNPCSpawn(int numTownNPCs, int money) {
 			if (Main.netMode == NetmodeID.SinglePlayer) {
 				for (int k = 0; k < 255; k++) {
 					Player player = Main.player[k];
@@ -214,7 +214,7 @@ namespace OrchidMod.NPCs.Town
 			shop.item[nextSlot].SetDefaults(ItemType<Gambler.GamblerDummy>());
 			nextSlot++;
 			
-            if (!player.ZoneBeach && !player.ZoneCorrupt && !player.ZoneSkyHeight  && !player.ZoneCrimson && !player.ZoneHoly && !player.ZoneJungle && !player.ZoneSnow && !player.ZoneDesert && !player.ZoneGlowshroom && player.ZoneOverworldHeight) {
+			if (!player.ZoneBeach && !player.ZoneCorrupt && !player.ZoneSkyHeight  && !player.ZoneCrimson && !player.ZoneHoly && !player.ZoneJungle && !player.ZoneSnow && !player.ZoneDesert && !player.ZoneGlowshroom && player.ZoneOverworldHeight) {
 				shop.item[nextSlot].SetDefaults(ItemType<Gambler.Weapons.Cards.ForestCard>());
 				nextSlot++;	
 			}

--- a/OrchidModGlobalNPC.cs
+++ b/OrchidModGlobalNPC.cs
@@ -411,7 +411,7 @@ namespace OrchidMod
 			
 			//THORIUM
 			
-			Mod thoriumMod = ModLoader.GetMod("ThoriumMod");
+			Mod thoriumMod = OrchidMod.ThoriumMod;
 			if (thoriumMod != null) {
 				if ((npc.type == thoriumMod.NPCType("TheGrandThunderBirdv2"))) {
 					if (!Main.expertMode) {
@@ -566,7 +566,7 @@ namespace OrchidMod
 				nextSlot++;
 			}
 			
-			Mod thoriumMod = ModLoader.GetMod("ThoriumMod");
+			Mod thoriumMod = OrchidMod.ThoriumMod;
 			if (thoriumMod != null) {
 				if (type == thoriumMod.NPCType("ConfusedZombie")) {
 					shop.item[nextSlot].SetDefaults(ItemType<Shaman.Weapons.Thorium.PatchWerkScepter>());

--- a/OrchidModLootBags.cs
+++ b/OrchidModLootBags.cs
@@ -180,7 +180,7 @@ namespace OrchidMod
 			
 			// THORIUM
 			
-			Mod thoriumMod = ModLoader.GetMod("ThoriumMod");
+			Mod thoriumMod = OrchidMod.ThoriumMod;
 			if (thoriumMod != null) {
 				if (context == "bossBag" && arg == thoriumMod.ItemType("ThunderBirdBag")) {
 					if (Main.rand.Next(4) == 0) {

--- a/OrchidModPlayer.cs
+++ b/OrchidModPlayer.cs
@@ -24,7 +24,7 @@ namespace OrchidMod
 {
 	public class OrchidModPlayer : ModPlayer
 	{
-		public Mod thoriumMod = ModLoader.GetMod("ThoriumMod");
+		public Mod thoriumMod = OrchidMod.ThoriumMod;
 		
 		public float OchidScreenH = Main.screenHeight;
 		public float OchidScreenW = Main.screenWidth;
@@ -278,6 +278,21 @@ namespace OrchidMod
 		public override void Load(TagCompound tag)
 		{
 			gamblerCardsItem = tag.GetList<TagCompound>("GamblerCardsItem").Select(ItemIO.Load).ToArray();
+			//If no cards were saved (old character, crash, etc), this can return Item[] of length 0
+			//In case of length not equaling 20, fix the array
+			if (gamblerCardsItem.Length != 20)
+			{
+				Array.Resize(ref gamblerCardsItem, 20);
+				for (int i = 0; i < gamblerCardsItem.Length; i++)
+				{
+					if (gamblerCardsItem[i] == null)
+					{
+						gamblerCardsItem[i] = new Item();
+						gamblerCardsItem[i].SetDefaults(0, true);
+					}
+				}
+			}
+
 			alchemistDailyHint = tag.GetBool("ChemistHint");
 			alchemistKnownReactions = tag.Get<List<int>>("AlchemistHidden");
 			alchemistKnownHints = tag.Get<List<int>>("AlchemistHints");

--- a/OrchidModPlayer.cs
+++ b/OrchidModPlayer.cs
@@ -24,8 +24,6 @@ namespace OrchidMod
 {
 	public class OrchidModPlayer : ModPlayer
 	{
-		public Mod thoriumMod = OrchidMod.ThoriumMod;
-		
 		public float OchidScreenH = Main.screenHeight;
 		public float OchidScreenW = Main.screenWidth;
 		public float OchidScreenHCompare;
@@ -320,18 +318,17 @@ namespace OrchidMod
 			OrchidModAlchemistHelper.alchemistPostUpdateEquips(player, this, mod);
 			OrchidModGamblerHelper.gamblerPostUpdateEquips(player, this, mod);
 			OrchidModDancerHelper.dancerPostUpdateEquips(player, this, mod);
-			
-			if (thoriumMod != null) {
-                //int thoriumCrit = player.GetModPlayer<ThoriumPlayer>().allCrit; // Impossible : can't add [using ThoriumMod;] because I don't have the ThoriumMod.dll file
-				
-				ModPlayer thoriumPlayer = player.GetModPlayer(this.thoriumMod, "ThoriumPlayer");
-				FieldInfo field = thoriumPlayer.GetType().GetField("allCrit", BindingFlags.Public | BindingFlags.Instance);
-				if (field != null) {
-					int thoriumCrit = (int)field.GetValue(thoriumPlayer);
+
+			Mod thoriumMod = OrchidMod.ThoriumMod;
+			if (thoriumMod != null)
+			{
+				object result = thoriumMod.Call("GetAllCrit", player);
+				if (result is int thoriumCrit && thoriumCrit > 0)
+				{
 					this.customCrit += thoriumCrit;
 				}
-            }
-     
+			}
+
 			this.shamanCrit += this.customCrit;
 			this.alchemistCrit += this.customCrit;
 			this.gamblerCrit += this.customCrit;

--- a/OrchidWorld.cs
+++ b/OrchidWorld.cs
@@ -29,6 +29,8 @@ using System.Linq;
 using Terraria.ModLoader.IO;
 using Microsoft.Xna.Framework.Graphics;
 using static Terraria.ModLoader.ModContent;
+using OrchidMod.Tiles.Ores;
+using OrchidMod.Tiles.Chests;
 
 namespace OrchidMod
 {
@@ -665,7 +667,7 @@ namespace OrchidMod
 					if (WorldGen.InWorld(k, l, 30) && fossil[y, x] == 1){
 						Tile tile = Framing.GetTileSafely(k, l);
 						tile.ClearTile();
-						WorldGen.PlaceTile(k, l, (ushort)ModLoader.GetMod("OrchidMod").TileType("AncientFossil"));
+						WorldGen.PlaceTile(k, l, (ushort)TileType<AncientFossil>());
 						tile.active(true);
 					}
 				}
@@ -1192,7 +1194,7 @@ namespace OrchidMod
 										continue;
 									}
 
-									int chestIndex = WorldGen.PlaceChest(x - 1, y - 1, (ushort)ModLoader.GetMod("OrchidMod").TileType("ShamanBiomeChest"), false, 1);
+									int chestIndex = WorldGen.PlaceChest(x - 1, y - 1, (ushort)TileType<ShamanBiomeChest>(), false, 1);
 
 									if (chestIndex < 0)
 									{
@@ -1262,7 +1264,7 @@ namespace OrchidMod
 			{
 				Chest chest = Main.chest[chestIndex];
 
-				if (chest != null && Main.tile[chest.x, chest.y].type == (ushort)ModLoader.GetMod("OrchidMod").TileType("MinersLockbox"))
+				if (chest != null && Main.tile[chest.x, chest.y].type == (ushort)TileType<MinersLockbox>())
 				{
 					int[] specialItemPoll = {49, 50, 53, 54, 55, 975, 997, 930, ItemType<Shaman.Weapons.EnchantedScepter>()
 					, ItemType<Alchemist.Weapons.Air.CloudInAVial>(), ItemType<Gambler.Weapons.Cards.GoldChestCard>()};
@@ -1281,7 +1283,7 @@ namespace OrchidMod
 					placeInChest(chest, rand, 1);
 				}
 
-				if (chest != null && Main.tile[chest.x, chest.y].type == (ushort)ModLoader.GetMod("OrchidMod").TileType("ShamanBiomeChest"))
+				if (chest != null && Main.tile[chest.x, chest.y].type == (ushort)TileType<ShamanBiomeChest>())
 				{
 					chest.item[0].SetDefaults(mod.ItemType("ShroomiteScepter"));
 					chest.item[1].SetDefaults(183); // Glowing Mushroom

--- a/Shaman/Armors/Thorium/OreHelms/TitanSpangenhelm.cs
+++ b/Shaman/Armors/Thorium/OreHelms/TitanSpangenhelm.cs
@@ -37,7 +37,7 @@ namespace OrchidMod.Shaman.Armors.Thorium.OreHelms
 		
 		public override bool IsArmorSet(Item head, Item body, Item legs)
         {
-			Mod thoriumMod = ModLoader.GetMod("ThoriumMod");
+			Mod thoriumMod = OrchidMod.ThoriumMod;
 			if (thoriumMod != null) {
 				return body.type == thoriumMod.ItemType("TitanBreastplate") && legs.type == thoriumMod.ItemType("TitanGreaves");
 			} else {
@@ -63,7 +63,7 @@ namespace OrchidMod.Shaman.Armors.Thorium.OreHelms
 		
 		public override void AddRecipes()
 		{
-			Mod thoriumMod = ModLoader.GetMod("ThoriumMod");
+			Mod thoriumMod = OrchidMod.ThoriumMod;
 			if (thoriumMod != null) {
 				ModRecipe recipe = new ModRecipe(mod);
 				recipe.AddTile(thoriumMod.TileType("SoulForge"));		

--- a/Shaman/OrchidModShamanEquipable.cs
+++ b/Shaman/OrchidModShamanEquipable.cs
@@ -32,7 +32,7 @@ namespace OrchidMod.Shaman
 				tt.text = damageValue + " shamanic " + damageWord;
 			}
 			
-			Mod thoriumMod = ModLoader.GetMod("ThoriumMod");
+			Mod thoriumMod = OrchidMod.ThoriumMod;
 			if (thoriumMod != null) {
 				tooltips.Insert(1, new TooltipLine(mod, "ShamanTag", "-Shaman Class-") // 00C0FF
 				{

--- a/Shaman/OrchidModShamanItem.cs
+++ b/Shaman/OrchidModShamanItem.cs
@@ -27,7 +27,7 @@ namespace OrchidMod.Shaman
 			item.summon = false;
 			item.noMelee = true;
 			item.noUseGraphic = true;
-			Item.staff[item.type] = true;
+			Item.staff[item.type] = true; //TODO this goes in SetStaticDefaults (and will need changing of the SetStaticDefaults hook to have a Safe version)
 			item.crit = 4;
 			item.useStyle = 3;
 			OrchidModGlobalItem orchidItem = item.GetGlobalItem<OrchidModGlobalItem>();
@@ -40,7 +40,7 @@ namespace OrchidMod.Shaman
 			modPlayer.shamanDrawWeapon = item.useTime;
 			Vector2 mousePosition = Main.screenPosition + new Vector2((float)Main.mouseX, (float)Main.mouseY);
 			
-			Vector2 catalystCenter = modPlayer.shamanCatalystPosition + new Vector2(modPlayer.shamanCatalystTexture.Width / 2, modPlayer.shamanCatalystTexture.Height / 2);
+			Vector2 catalystCenter = modPlayer.shamanCatalystPosition + modPlayer.shamanCatalystTexture?.Size() ?? Vector2.Zero;
 			
 			if (Collision.CanHit(position, 0, 0, position + (catalystCenter - position), 0, 0)) {
 				position = catalystCenter;
@@ -65,7 +65,10 @@ namespace OrchidMod.Shaman
 			if (modPlayer.shamanSelectedItem != item.type) {
 				modPlayer.shamanSelectedItem = item.type;
 				string textureLocation = "OrchidMod/Shaman/CatalystTextures/" + this.Name + "_Catalyst";
-				modPlayer.shamanCatalystTexture = ModContent.GetTexture(textureLocation);
+				if (TextureExists(textureLocation))
+				{
+					modPlayer.shamanCatalystTexture = GetTexture(textureLocation);
+				}
 			}
 			
 			modPlayer.shamanCatalyst = 3;

--- a/Shaman/Projectiles/Thorium/BersekerShardScepterProj.cs
+++ b/Shaman/Projectiles/Thorium/BersekerShardScepterProj.cs
@@ -57,7 +57,7 @@ namespace OrchidMod.Shaman.Projectiles.Thorium
 		public override void SafeOnHitNPC(NPC target, int damage, float knockback, bool crit, Player player, OrchidModPlayer modPlayer)
 		{
 			if (OrchidModShamanHelper.getNbShamanicBonds(player, modPlayer, mod) > 4) {
-				Mod thoriumMod = ModLoader.GetMod("ThoriumMod");
+				Mod thoriumMod = OrchidMod.ThoriumMod;
 				if (thoriumMod != null) {
 					target.AddBuff((thoriumMod.BuffType("BerserkSoul")), 5 * 60);
 				}

--- a/Shaman/Projectiles/Thorium/BoreanStriderScepterProj.cs
+++ b/Shaman/Projectiles/Thorium/BoreanStriderScepterProj.cs
@@ -61,7 +61,7 @@ namespace OrchidMod.Shaman.Projectiles.Thorium
 		
 		public override void SafeOnHitNPC(NPC target, int damage, float knockback, bool crit, Player player, OrchidModPlayer modPlayer)
 		{
-			Mod thoriumMod = ModLoader.GetMod("ThoriumMod");
+			Mod thoriumMod = OrchidMod.ThoriumMod;
 			if (thoriumMod != null) {
 				target.AddBuff((thoriumMod.BuffType("Freezing")), 2 * 60);
 			}

--- a/Shaman/Projectiles/Thorium/BoreanStriderScepterProjAlt.cs
+++ b/Shaman/Projectiles/Thorium/BoreanStriderScepterProjAlt.cs
@@ -51,7 +51,7 @@ namespace OrchidMod.Shaman.Projectiles.Thorium
 		
 		public override void SafeOnHitNPC(NPC target, int damage, float knockback, bool crit, Player player, OrchidModPlayer modPlayer)
 		{
-			Mod thoriumMod = ModLoader.GetMod("ThoriumMod");
+			Mod thoriumMod = OrchidMod.ThoriumMod;
 			if (thoriumMod != null) {
 				target.AddBuff((thoriumMod.BuffType("Freezing")), 2 * 60);
 			}

--- a/Shaman/Projectiles/Thorium/BronzeAlloyScepterProjAlt.cs
+++ b/Shaman/Projectiles/Thorium/BronzeAlloyScepterProjAlt.cs
@@ -50,7 +50,7 @@ namespace OrchidMod.Shaman.Projectiles.Thorium
 		
 		public override void SafeOnHitNPC(NPC target, int damage, float knockback, bool crit, Player player, OrchidModPlayer modPlayer)
 		{
-			Mod thoriumMod = ModLoader.GetMod("ThoriumMod");
+			Mod thoriumMod = OrchidMod.ThoriumMod;
 			if (thoriumMod != null) {
 				target.AddBuff((thoriumMod.BuffType("Petrify")), 3 * 60);
 			}

--- a/Shaman/Projectiles/Thorium/OrchidScepterProj.cs
+++ b/Shaman/Projectiles/Thorium/OrchidScepterProj.cs
@@ -63,7 +63,7 @@ namespace OrchidMod.Shaman.Projectiles.Thorium
 		
 		public override void SafeOnHitNPC(NPC target, int damage, float knockback, bool crit, Player player, OrchidModPlayer modPlayer)
 		{
-			Mod thoriumMod = ModLoader.GetMod("ThoriumMod");
+			Mod thoriumMod = OrchidMod.ThoriumMod;
 			if (thoriumMod != null) {
 				player.AddBuff((thoriumMod.BuffType("OverGrowth")), 3 * 60);
 			}

--- a/Shaman/Projectiles/Thorium/OreOrbs/Big/LodestoneScepterExplosion.cs
+++ b/Shaman/Projectiles/Thorium/OreOrbs/Big/LodestoneScepterExplosion.cs
@@ -47,7 +47,7 @@ namespace OrchidMod.Shaman.Projectiles.Thorium.OreOrbs.Big
 
 		public override void SafeOnHitNPC(NPC target, int damage, float knockback, bool crit, Player player, OrchidModPlayer modPlayer)
 		{
-			Mod thoriumMod = ModLoader.GetMod("ThoriumMod");
+			Mod thoriumMod = OrchidMod.ThoriumMod;
 			if (thoriumMod != null) {
 				target.AddBuff((thoriumMod.BuffType("Sunder")), 10 * 60);
 			}

--- a/Shaman/Projectiles/Thorium/OreOrbs/Big/LodestoneScepterProj.cs
+++ b/Shaman/Projectiles/Thorium/OreOrbs/Big/LodestoneScepterProj.cs
@@ -60,7 +60,7 @@ namespace OrchidMod.Shaman.Projectiles.Thorium.OreOrbs.Big
 		
 		public override void SafeOnHitNPC(NPC target, int damage, float knockback, bool crit, Player player, OrchidModPlayer modPlayer)
 		{	
-			Mod thoriumMod = ModLoader.GetMod("ThoriumMod");
+			Mod thoriumMod = OrchidMod.ThoriumMod;
 			if (thoriumMod != null && Main.rand.Next(5) == 0) {
 				target.AddBuff((thoriumMod.BuffType("Sunder")), 4 * 60);
 			}

--- a/Shaman/Projectiles/Thorium/OreOrbs/Big/MagmaScepterProj.cs
+++ b/Shaman/Projectiles/Thorium/OreOrbs/Big/MagmaScepterProj.cs
@@ -77,7 +77,7 @@ namespace OrchidMod.Shaman.Projectiles.Thorium.OreOrbs.Big
 		
 		public override void SafeOnHitNPC(NPC target, int damage, float knockback, bool crit, Player player, OrchidModPlayer modPlayer)
 		{
-			Mod thoriumMod = ModLoader.GetMod("ThoriumMod");
+			Mod thoriumMod = OrchidMod.ThoriumMod;
 			if (thoriumMod != null && Main.rand.Next(2) == 0) {
 				target.AddBuff((thoriumMod.BuffType("Singed")), 2 * 60);
 			}

--- a/Shaman/Projectiles/Thorium/OreOrbs/Big/MagmaScepterProjExplosion.cs
+++ b/Shaman/Projectiles/Thorium/OreOrbs/Big/MagmaScepterProjExplosion.cs
@@ -29,7 +29,7 @@ namespace OrchidMod.Shaman.Projectiles.Thorium.OreOrbs.Big
 
 		public override void SafeOnHitNPC(NPC target, int damage, float knockback, bool crit, Player player, OrchidModPlayer modPlayer)
 		{
-			Mod thoriumMod = ModLoader.GetMod("ThoriumMod");
+			Mod thoriumMod = OrchidMod.ThoriumMod;
 			if (thoriumMod != null) {
 				target.AddBuff((thoriumMod.BuffType("Singed")), 5 * 60);
 			}

--- a/Shaman/Projectiles/Thorium/OreOrbs/Big/MonowaiExplosion.cs
+++ b/Shaman/Projectiles/Thorium/OreOrbs/Big/MonowaiExplosion.cs
@@ -29,7 +29,7 @@ namespace OrchidMod.Shaman.Projectiles.Thorium.OreOrbs.Big
 
 		public override void SafeOnHitNPC(NPC target, int damage, float knockback, bool crit, Player player, OrchidModPlayer modPlayer)
 		{
-			Mod thoriumMod = ModLoader.GetMod("ThoriumMod");
+			Mod thoriumMod = OrchidMod.ThoriumMod;
 			if (thoriumMod != null) {
 				target.AddBuff((thoriumMod.BuffType("Singed")), 5 * 60);
 			}

--- a/Shaman/Projectiles/Thorium/OreOrbs/Big/MonowaiProj.cs
+++ b/Shaman/Projectiles/Thorium/OreOrbs/Big/MonowaiProj.cs
@@ -74,7 +74,7 @@ namespace OrchidMod.Shaman.Projectiles.Thorium.OreOrbs.Big
 		
 		public override void SafeOnHitNPC(NPC target, int damage, float knockback, bool crit, Player player, OrchidModPlayer modPlayer)
 		{
-			Mod thoriumMod = ModLoader.GetMod("ThoriumMod");
+			Mod thoriumMod = OrchidMod.ThoriumMod;
 			if (thoriumMod != null && Main.rand.Next(2) == 0) {
 				target.AddBuff((thoriumMod.BuffType("Singed")), 2 * 60);
 			}

--- a/Shaman/Projectiles/Thorium/OreOrbs/Big/ValadiumScepterProj.cs
+++ b/Shaman/Projectiles/Thorium/OreOrbs/Big/ValadiumScepterProj.cs
@@ -74,7 +74,7 @@ namespace OrchidMod.Shaman.Projectiles.Thorium.OreOrbs.Big
 		
 		public override void SafeOnHitNPC(NPC target, int damage, float knockback, bool crit, Player player, OrchidModPlayer modPlayer)
 		{
-			Mod thoriumMod = ModLoader.GetMod("ThoriumMod");
+			Mod thoriumMod = OrchidMod.ThoriumMod;
 			if (thoriumMod != null && Main.rand.Next(2) == 0) {
 				target.AddBuff((thoriumMod.BuffType("LightCurse")), 1 * 60);
 			}

--- a/Shaman/Projectiles/Thorium/OreOrbs/Circle/GraniteEnergyScepterProj.cs
+++ b/Shaman/Projectiles/Thorium/OreOrbs/Circle/GraniteEnergyScepterProj.cs
@@ -57,7 +57,7 @@ namespace OrchidMod.Shaman.Projectiles.Thorium.OreOrbs.Circle
 		
 		public override void SafeOnHitNPC(NPC target, int damage, float knockback, bool crit, Player player, OrchidModPlayer modPlayer)
 		{
-			Mod thoriumMod = ModLoader.GetMod("ThoriumMod");
+			Mod thoriumMod = OrchidMod.ThoriumMod;
 			if (thoriumMod != null) {
 				target.AddBuff((thoriumMod.BuffType("GraniteSurge")), 3 * 60);
 			}

--- a/Shaman/Projectiles/Thorium/OreOrbs/Large/TerrariumScepterOrbProj.cs
+++ b/Shaman/Projectiles/Thorium/OreOrbs/Large/TerrariumScepterOrbProj.cs
@@ -95,7 +95,7 @@ namespace OrchidMod.Shaman.Projectiles.Thorium.OreOrbs.Large
 		
 		public override void SafeOnHitNPC(NPC target, int damage, float knockback, bool crit, Player player, OrchidModPlayer modPlayer)
 		{
-			Mod thoriumMod = ModLoader.GetMod("ThoriumMod");
+			Mod thoriumMod = OrchidMod.ThoriumMod;
 			if (thoriumMod != null) {
 				target.AddBuff((thoriumMod.BuffType("TerrariumMix")), 2 * 60);
 			}

--- a/Shaman/Projectiles/Thorium/OreOrbs/Large/TerrariumScepterProj.cs
+++ b/Shaman/Projectiles/Thorium/OreOrbs/Large/TerrariumScepterProj.cs
@@ -108,7 +108,7 @@ namespace OrchidMod.Shaman.Projectiles.Thorium.OreOrbs.Large
 		
 		public override void SafeOnHitNPC(NPC target, int damage, float knockback, bool crit, Player player, OrchidModPlayer modPlayer)
 		{
-			Mod thoriumMod = ModLoader.GetMod("ThoriumMod");
+			Mod thoriumMod = OrchidMod.ThoriumMod;
 			if (thoriumMod != null) {
 				target.AddBuff((thoriumMod.BuffType("TerrariumMix")), 2 * 60);
 			}

--- a/Shaman/Projectiles/Thorium/OreOrbs/Unique/SolarPebbleScepterOrbProj.cs
+++ b/Shaman/Projectiles/Thorium/OreOrbs/Unique/SolarPebbleScepterOrbProj.cs
@@ -63,7 +63,7 @@ namespace OrchidMod.Shaman.Projectiles.Thorium.OreOrbs.Unique
 		
 		public override void SafeOnHitNPC(NPC target, int damage, float knockback, bool crit, Player player, OrchidModPlayer modPlayer)
 		{
-			Mod thoriumMod = ModLoader.GetMod("ThoriumMod");
+			Mod thoriumMod = OrchidMod.ThoriumMod;
 			if (thoriumMod != null) {
 				target.AddBuff((thoriumMod.BuffType("Melting")), 2 * 60);
 			}

--- a/Shaman/Projectiles/Thorium/OreOrbs/Unique/SolarPebbleScepterProj.cs
+++ b/Shaman/Projectiles/Thorium/OreOrbs/Unique/SolarPebbleScepterProj.cs
@@ -77,7 +77,7 @@ namespace OrchidMod.Shaman.Projectiles.Thorium.OreOrbs.Unique
 		
 		public override void SafeOnHitNPC(NPC target, int damage, float knockback, bool crit, Player player, OrchidModPlayer modPlayer)
 		{
-			Mod thoriumMod = ModLoader.GetMod("ThoriumMod");
+			Mod thoriumMod = OrchidMod.ThoriumMod;
 			if (thoriumMod != null) {
 				target.AddBuff((thoriumMod.BuffType("Melting")), 2 * 60);
 			}

--- a/Shaman/Projectiles/Thorium/UnfathomableFleshScepterProj.cs
+++ b/Shaman/Projectiles/Thorium/UnfathomableFleshScepterProj.cs
@@ -70,7 +70,7 @@ namespace OrchidMod.Shaman.Projectiles.Thorium
 					player.HealEffect(5, true);
 				player.statLife += 5;
 				
-				Mod thoriumMod = ModLoader.GetMod("ThoriumMod");
+				Mod thoriumMod = OrchidMod.ThoriumMod;
 				if (thoriumMod != null) {
 					player.AddBuff((thoriumMod.BuffType("LifeTransfusion")), 5 * 60);
 				}

--- a/Shaman/Weapons/Hardmode/MartianBeamer.cs
+++ b/Shaman/Weapons/Hardmode/MartianBeamer.cs
@@ -34,18 +34,12 @@ namespace OrchidMod.Shaman.Weapons.Hardmode
 		  DisplayName.SetDefault("Martian Beamer");
 		  Tooltip.SetDefault("Shoots martian homing lasers"
 							+"\nWeapon speed increases with the number of active shamanic bonds");
-		}
-		
-		public override void ModifyWeaponDamage(Player player, ref float add, ref float mult, ref float flat) {
-			mult *= player.GetModPlayer<OrchidModPlayer>().shamanDamage;
-			
-			Mod thoriumMod = ModLoader.GetMod("ThoriumMod");
-			if (thoriumMod != null) {
-				ModPlayer thoriumPlayer = player.GetModPlayer(thoriumMod, "ThoriumPlayer");
-				FieldInfo field = thoriumPlayer.GetType().GetField("martianDamage", BindingFlags.Public | BindingFlags.Instance);
-				float martianDamage = (float)field.GetValue(thoriumPlayer);
-				mult *= martianDamage;
-            }
+
+			Mod thoriumMod = OrchidMod.ThoriumMod;
+			if (thoriumMod != null)
+			{
+				thoriumMod.Call("AddMartianItemID", item.type);
+			}
 		}
 		
 		public override void UpdateInventory(Player player) {

--- a/Shaman/Weapons/Hardmode/TrueDepthsBaton.cs
+++ b/Shaman/Weapons/Hardmode/TrueDepthsBaton.cs
@@ -5,8 +5,9 @@ using Terraria;
 using Terraria.DataStructures;
 using Terraria.ID;
 using Terraria.ModLoader;
+using OrchidMod.Shaman.Misc;
+using static Terraria.ModLoader.ModContent;
 
- 
 namespace OrchidMod.Shaman.Weapons.Hardmode
 {
     public class TrueDepthsBaton : OrchidModShamanItem
@@ -89,7 +90,7 @@ namespace OrchidMod.Shaman.Weapons.Hardmode
             // list.RemoveAt(index);
             // list.Insert(index, new TooltipLine(mod, "Damage", split[0] + " - " + dmg2 + " shamanic damage"));
 			
-			// Mod thoriumMod = ModLoader.GetMod("ThoriumMod");
+			// Mod thoriumMod = OrchidMod.ThoriumMod;
 			// if (thoriumMod != null) {
 				// list.Insert(1, new TooltipLine(mod, "Class", "[c/666DFF:-Shaman Class-]"));
 			// }
@@ -97,12 +98,11 @@ namespace OrchidMod.Shaman.Weapons.Hardmode
 		
 		public override void AddRecipes()
 		{
-			Mod orchidMod = ModLoader.GetMod("OrchidMod");
-			Mod thoriumMod = ModLoader.GetMod("ThoriumMod");
+			Mod thoriumMod = OrchidMod.ThoriumMod;
 			
 			ModRecipe recipe = new ModRecipe(mod);
-			recipe.AddIngredient(orchidMod.ItemType("DepthsBaton"), 1);
-			recipe.AddIngredient((thoriumMod != null) ? thoriumMod.ItemType("BrokenHeroFragment") : orchidMod.ItemType("BrokenHeroScepter"), (thoriumMod != null) ? 2 : 1);
+			recipe.AddIngredient(ItemType<DepthsBaton>(), 1);
+			recipe.AddIngredient((thoriumMod != null) ? thoriumMod.ItemType("BrokenHeroFragment") : ItemType<BrokenHeroScepter>(), (thoriumMod != null) ? 2 : 1);
 			recipe.AddTile(TileID.MythrilAnvil);
 			recipe.SetResult(this);
 			recipe.AddRecipe();

--- a/Shaman/Weapons/Hardmode/TrueSanctify.cs
+++ b/Shaman/Weapons/Hardmode/TrueSanctify.cs
@@ -5,6 +5,8 @@ using Terraria;
 using Terraria.DataStructures;
 using Terraria.ID;
 using Terraria.ModLoader;
+using OrchidMod.Shaman.Misc;
+using static Terraria.ModLoader.ModContent;
 
 namespace OrchidMod.Shaman.Weapons.Hardmode
 {
@@ -58,12 +60,11 @@ namespace OrchidMod.Shaman.Weapons.Hardmode
 		
 		public override void AddRecipes()
 		{
-			Mod orchidMod = ModLoader.GetMod("OrchidMod");
-			Mod thoriumMod = ModLoader.GetMod("ThoriumMod");
+			Mod thoriumMod = OrchidMod.ThoriumMod;
 			
 			ModRecipe recipe = new ModRecipe(mod);
-			recipe.AddIngredient(orchidMod.ItemType("Sanctify"), 1);
-			recipe.AddIngredient((thoriumMod != null) ? thoriumMod.ItemType("BrokenHeroFragment") : orchidMod.ItemType("BrokenHeroScepter"), (thoriumMod != null) ? 2 : 1);
+			recipe.AddIngredient(ItemType<Sanctify>(), 1);
+			recipe.AddIngredient((thoriumMod != null) ? thoriumMod.ItemType("BrokenHeroFragment") : ItemType<BrokenHeroScepter>(), (thoriumMod != null) ? 2 : 1);
 			recipe.AddTile(TileID.MythrilAnvil);
 			recipe.SetResult(this);
 			recipe.AddRecipe();


### PR DESCRIPTION
With the latest Thorium 1.6.5.0 update, there are now more `mod.Calls` to use, which reduces the amount of reflection. In addition, most things regarding thorium have been cleaned up a bit, aswell as adjusted due to new code on thoriums side (warlock and iridescent set bonus changes)

* Fixed compilation due to ExampleMod usage
* Fixed errors due to gambler deck being empty on player load
* Fixed errors due to missing catalyst textures
* Possibly fixed gambler deck check not getting synced, which prevented the Croupier NPC from moving in (please test this)