### PR TITLE
Shadow Orbs & Crimson Hearts now drop items appropriately

### DIFF
--- a/OrchidModGlobalTile.cs
+++ b/OrchidModGlobalTile.cs
@@ -1,46 +1,32 @@
 using Terraria;
+using Terraria.ID;
 using Terraria.ModLoader;
-using static Terraria.ModLoader.ModContent;
 
 namespace OrchidMod
 {
 	public class ModGlobalTile : GlobalTile
 	{
-		public override void KillTile(int i, int j, int type, ref bool fail, ref bool effectOnly, ref bool noItem)
+		public override bool Drop(int i, int j, int type)
 		{
-			if (type == 28)
+			if (type == TileID.Pots)
 			{
 				if (Main.rand.Next(1500) == 0)
 				{
-					Item.NewItem(i * 16, j * 16, 32, 48, ItemType<Gambler.Weapons.Cards.HealingPotionCard>());
+					Item.NewItem(i * 16, j * 16, 32, 32, mod.ItemType("HealingPotionCard"));
 				}
 			}
-			if (type == 31)
+			if (type == TileID.ShadowOrbs && Main.tile[i, j].frameY == 0 && Main.tile[i, j].frameX % 36 == 0)
 			{
-				if (Main.tile[i, j].frameX == 1 * 36 && Main.tile[i, j].frameY == 0)
+				if (Main.rand.Next(6) == 0)
 				{
-					if (Main.rand.Next(6) == 0)
-					{
-						Item.NewItem(i * 16, j * 16, 32, 48, ItemType<Shaman.Weapons.BloodCaller>());
-					}
-					if (Main.rand.Next(5) == 0)
-					{
-						Item.NewItem(i * 16, j * 16, 32, 48, ItemType<Alchemist.Weapons.Catalysts.CrimtaneCatalyst>());
-					}
+					Item.NewItem(i * 16, j * 16, 32, 32, (Main.tile[i, j].frameX == 0) ? mod.ItemType("ShadowWeaver") : mod.ItemType("BloodCaller"));
 				}
-				if (Main.tile[i, j].frameX == 0 && Main.tile[i, j].frameY == 0)
+				if (Main.rand.Next(5) == 0)
 				{
-					if (Main.rand.Next(6) == 0)
-					{
-						Item.NewItem(i * 16, j * 16, 32, 48, ItemType<Shaman.Weapons.ShadowWeaver>());
-					}
-					if (Main.rand.Next(5) == 0)
-					{
-						Item.NewItem(i * 16, j * 16, 32, 48, ItemType<Alchemist.Weapons.Catalysts.DemoniteCatalyst>());
-					}
+					Item.NewItem(i * 16, j * 16, 32, 32, (Main.tile[i, j].frameX == 0) ? mod.ItemType("DemoniteCatalyst") : mod.ItemType("CrimtaneCatalyst"));
 				}
 			}
+			return base.Drop(i, j, type);
 		}
-
 	}
 }


### PR DESCRIPTION
Shadow Orbs & Crimson Hearts drop items even though they are prevented from being a broke. In my case I had these tiles blocked from being broke to prevent players from fighting evil bosses on a dedicated server. This revealed an issue. Shadow Weaver, Blood Caller, Demonite Catalyst, and Crimtane Catalyst would infinitely drop when the Shadow Orb & Crimson Heart tiles were hit in the top-left corner. I found a better method for these items to drop by overriding `Drop` in `GlobalTile`.